### PR TITLE
MPI_Type, MPI_Alltoallw, mpp_global_field update

### DIFF
--- a/mpp/include/mpp_alltoall_nocomm.h
+++ b/mpp/include/mpp_alltoall_nocomm.h
@@ -18,7 +18,6 @@
 !***********************************************************************
 
 subroutine MPP_ALLTOALL_(sbuf, scount, rbuf, rcount, pelist)
-
     MPP_TYPE_, dimension(:), intent(in) :: sbuf
     MPP_TYPE_, dimension(:), intent(inout) :: rbuf
     integer,   intent(in) :: scount, rcount
@@ -39,7 +38,6 @@ end subroutine MPP_ALLTOALL_
 
 
 subroutine MPP_ALLTOALLV_(sbuf, ssize, sdispl, rbuf, rsize, rdispl, pelist)
-
     MPP_TYPE_, intent(in) :: sbuf(:)
     MPP_TYPE_, intent(inout) :: rbuf(:)
 
@@ -59,3 +57,27 @@ subroutine MPP_ALLTOALLV_(sbuf, ssize, sdispl, rbuf, rsize, rdispl, pelist)
         call increment_current_clock(EVENT_ALLTOALL, MPP_TYPE_BYTELEN_)
 
 end subroutine MPP_ALLTOALLV_
+
+
+subroutine MPP_ALLTOALLW_(sbuf, ssize, sdispl, stype, &
+                          rbuf, rsize, rdispl, rtype, pelist)
+    MPP_TYPE_, intent(in) :: sbuf(:)
+    MPP_TYPE_, intent(inout) :: rbuf(:)
+
+    integer, intent(in) :: ssize(:), rsize(:)
+    integer, intent(in) :: sdispl(:), rdispl(:)
+    type(mpp_type), intent(in) :: stype(:), rtype(:)
+
+    integer, intent(in), optional :: pelist(0:)
+
+    if (.NOT. module_is_initialized) &
+        call mpp_error(FATAL, 'MPP_ALLTOALL: You must first call mpp_init.')
+
+    if (current_clock .NE. 0) call SYSTEM_CLOCK(start_tick)
+
+    rbuf(:) = sbuf(:)
+
+    if (current_clock .NE. 0) &
+        call increment_current_clock(EVENT_ALLTOALL, MPP_TYPE_BYTELEN_)
+
+end subroutine MPP_ALLTOALLW_

--- a/mpp/include/mpp_alltoall_sma.h
+++ b/mpp/include/mpp_alltoall_sma.h
@@ -18,7 +18,6 @@
 !***********************************************************************
 
 subroutine MPP_ALLTOALL_(sbuf, scount, rbuf, rcount, pelist)
-
     MPP_TYPE_, dimension(:), intent(in) :: sbuf
     MPP_TYPE_, dimension(:), intent(inout) :: rbuf
     integer,   intent(in) :: scount, rcount
@@ -31,7 +30,6 @@ end subroutine MPP_ALLTOALL_
 
 
 subroutine MPP_ALLTOALLV_(sbuf, ssize, sdispl, rbuf, rsize, rdispl, pelist)
-
     MPP_TYPE_, intent(in) :: sbuf(:)
     MPP_TYPE_, intent(inout) :: rbuf(:)
 
@@ -43,3 +41,19 @@ subroutine MPP_ALLTOALLV_(sbuf, ssize, sdispl, rbuf, rsize, rdispl, pelist)
     call mpp_error(FATAL, 'MPP_ALLTOALLV: No SHMEM implementation.')
 
 end subroutine MPP_ALLTOALLV_
+
+
+subroutine MPP_ALLTOALLW_(sbuf, ssize, sdispl, stype, &
+                          rbuf, rsize, rdispl, rtype, pelist)
+    MPP_TYPE_, intent(in) :: sbuf(:)
+    MPP_TYPE_, intent(inout) :: rbuf(:)
+
+    integer, intent(in) :: ssize(:), rsize(:)
+    integer, intent(in) :: sdispl(:), rdispl(:)
+    type(mpp_type), intent(in) :: stype(:), rtype(:)
+
+    integer, intent(in), optional :: pelist(0:)
+
+    call mpp_error(FATAL, 'MPP_ALLTOALLW: No SHMEM implementation.')
+
+end subroutine MPP_ALLTOALLW_

--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -34,6 +34,7 @@
   logical                       :: opened, existed
   integer                       :: unit_begin, unit_end, unit_nml, io_status
   character(len=5) :: this_pe
+  type(mpp_type), pointer :: dtype
 
   if( module_is_initialized )return
 
@@ -78,6 +79,23 @@
   call SYSTEM_CLOCK( count=tick0, count_rate=ticks_per_sec, count_max=max_ticks )
   tick_rate = 1./ticks_per_sec
   clock0 = mpp_clock_id( 'Total runtime', flags=MPP_CLOCK_SYNC )
+
+  ! Create the bytestream (default) mpp_datatype
+  mpp_byte%counter = 1
+  mpp_byte%ndims = 0
+  allocate(mpp_byte%sizes(0))
+  allocate(mpp_byte%subsizes(0))
+  allocate(mpp_byte%starts(0))
+  mpp_byte%etype = MPI_BYTE
+  mpp_byte%id = MPI_BYTE
+
+  mpp_byte%prev => null()
+  mpp_byte%next => null()
+
+  ! Initialize datatype list with mpp_byte
+  datatypes%head => mpp_byte
+  datatypes%tail => mpp_byte
+  datatypes%length = 0
 
   if( PRESENT(flags) )then
      debug   = flags.EQ.MPP_DEBUG
@@ -204,6 +222,7 @@ subroutine mpp_exit()
   real    :: t, tmin, tmax, tavg, tstd
   real    :: m, mmin, mmax, mavg, mstd, t_total
   logical :: opened
+  type(mpp_type), pointer :: dtype
 
   if( .NOT.module_is_initialized )return
   call mpp_set_current_pelist()
@@ -291,13 +310,19 @@ subroutine mpp_exit()
    close(etc_unit)
   endif
 
+  ! Clear derived data types (skipping list head, mpp_byte)
+  dtype => datatypes%head
+  do while (.not. associated(dtype))
+      dtype => dtype%next
+      dtype%counter = 1         ! Force deallocation
+      call mpp_type_free(dtype)
+  end do
+
   call mpp_set_current_pelist()
   call mpp_sync()
   call mpp_max(mpp_stack_hwm)
   if( pe.EQ.root_pe )write( out_unit,* )'MPP_STACK high water mark=', mpp_stack_hwm
   if(mpp_comm_private == MPI_COMM_WORLD ) call MPI_FINALIZE(error)
-
-
 
   return
 end subroutine mpp_exit
@@ -1141,11 +1166,13 @@ end subroutine mpp_gsm_free
 
 #undef MPP_ALLTOALL_
 #undef MPP_ALLTOALLV_
+#undef MPP_ALLTOALLW_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_int4
 #define MPP_ALLTOALLV_ mpp_alltoall_int4_v
+#define MPP_ALLTOALLW_ mpp_alltoall_int4_w
 #define MPP_TYPE_ integer(INT_KIND)
 #define MPP_TYPE_BYTELEN_ 4
 #define MPI_TYPE_ MPI_INTEGER4
@@ -1153,11 +1180,13 @@ end subroutine mpp_gsm_free
 
 #undef MPP_ALLTOALL_
 #undef MPP_ALLTOALLV_
+#undef MPP_ALLTOALLW_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_int8
 #define MPP_ALLTOALLV_ mpp_alltoall_int8_v
+#define MPP_ALLTOALLW_ mpp_alltoall_int8_w
 #define MPP_TYPE_ integer(LONG_KIND)
 #define MPP_TYPE_BYTELEN_ 8
 #define MPI_TYPE_ MPI_INTEGER8
@@ -1165,11 +1194,13 @@ end subroutine mpp_gsm_free
 
 #undef MPP_ALLTOALL_
 #undef MPP_ALLTOALLV_
+#undef MPP_ALLTOALLW_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_real4
 #define MPP_ALLTOALLV_ mpp_alltoall_real4_v
+#define MPP_ALLTOALLW_ mpp_alltoall_real4_w
 #define MPP_TYPE_ real(FLOAT_KIND)
 #define MPP_TYPE_BYTELEN_ 4
 #define MPI_TYPE_ MPI_REAL4
@@ -1177,12 +1208,120 @@ end subroutine mpp_gsm_free
 
 #undef MPP_ALLTOALL_
 #undef MPP_ALLTOALLV_
+#undef MPP_ALLTOALLW_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_real8
 #define MPP_ALLTOALLV_ mpp_alltoall_real8_v
+#define MPP_ALLTOALLW_ mpp_alltoall_real8_w
 #define MPP_TYPE_ real(DOUBLE_KIND)
 #define MPP_TYPE_BYTELEN_ 8
 #define MPI_TYPE_ MPI_REAL8
 #include <mpp_alltoall_mpi.h>
+
+#undef MPP_ALLTOALL_
+#undef MPP_ALLTOALLV_
+#undef MPP_ALLTOALLW_
+#undef MPP_TYPE_
+#undef MPP_TYPE_BYTELEN_
+#undef MPI_TYPE_
+#define MPP_ALLTOALL_ mpp_alltoall_logical4
+#define MPP_ALLTOALLV_ mpp_alltoall_logical4_v
+#define MPP_ALLTOALLW_ mpp_alltoall_logical4_w
+#define MPP_TYPE_ logical(INT_KIND)
+#define MPP_TYPE_BYTELEN_ 4
+#define MPI_TYPE_ MPI_INTEGER4
+#include <mpp_alltoall_mpi.h>
+
+#undef MPP_ALLTOALL_
+#undef MPP_ALLTOALLV_
+#undef MPP_ALLTOALLW_
+#undef MPP_TYPE_
+#undef MPP_TYPE_BYTELEN_
+#undef MPI_TYPE_
+#define MPP_ALLTOALL_ mpp_alltoall_logical8
+#define MPP_ALLTOALLV_ mpp_alltoall_logical8_v
+#define MPP_ALLTOALLW_ mpp_alltoall_logical8_w
+#define MPP_TYPE_ logical(LONG_KIND)
+#define MPP_TYPE_BYTELEN_ 8
+#define MPI_TYPE_ MPI_INTEGER8
+#include <mpp_alltoall_mpi.h>
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!                                                                             !
+!            DATA TRANSFER TYPES: mpp_type_create, mpp_type_free              !
+!                                                                             !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+#define MPP_TYPE_CREATE_ mpp_type_create_int4
+#define MPP_TYPE_ integer(INT_KIND)
+#define MPI_TYPE_ MPI_INTEGER4
+#include <mpp_type_mpi.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_int8
+#define MPP_TYPE_ integer(LONG_KIND)
+#define MPI_TYPE_ MPI_INTEGER8
+#include <mpp_type_mpi.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_real4
+#define MPP_TYPE_ real(FLOAT_KIND)
+#define MPI_TYPE_ MPI_REAL4
+#include <mpp_type_mpi.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_real8
+#define MPP_TYPE_ real(DOUBLE_KIND)
+#define MPI_TYPE_ MPI_REAL8
+#include <mpp_type_mpi.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_logical4
+#define MPP_TYPE_ logical(INT_KIND)
+#define MPI_TYPE_ MPI_INTEGER4
+#include <mpp_type_mpi.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_logical8
+#define MPP_TYPE_ logical(LONG_KIND)
+#define MPI_TYPE_ MPI_INTEGER8
+#include <mpp_type_mpi.h>
+
+! Clear preprocessor flags
+#undef MPI_TYPE_
+#undef MPP_TYPE_
+#undef MPP_TYPE_CREATE_
+
+! NOTE: This should probably not take a pointer, but for now we do this.
+subroutine mpp_type_free(dtype)
+    type(mpp_type), pointer, intent(inout) :: dtype
+
+    if (.NOT. module_is_initialized) &
+        call mpp_error(FATAL, 'MPP_TYPE_FREE: You must first call mpp_init.')
+
+    if (current_clock .NE. 0) &
+        call SYSTEM_CLOCK(start_tick)
+
+    if (verbose) &
+        call mpp_error(NOTE, 'MPP_TYPE_FREE: using MPI_Type_free...')
+
+    ! Decrement the reference counter
+    dtype%counter = dtype%counter - 1
+
+    if (dtype%counter < 1) then
+        ! De-register the datatype in MPI runtime
+        call MPI_Type_free(dtype%id, error)
+
+        ! Remove from list
+        dtype%prev => dtype%next
+
+        ! Remove from memory
+        if (allocated(dtype%sizes)) deallocate(dtype%sizes)
+        if (allocated(dtype%subsizes)) deallocate(dtype%subsizes)
+        if (allocated(dtype%starts)) deallocate(dtype%starts)
+        deallocate(dtype)
+
+        datatypes%length = datatypes%length - 1
+    end if
+
+    if (current_clock .NE. 0) &
+        call increment_current_clock(EVENT_TYPE_FREE, MPP_TYPE_BYTELEN_)
+
+end subroutine mpp_type_free

--- a/mpp/include/mpp_comm_nocomm.inc
+++ b/mpp/include/mpp_comm_nocomm.inc
@@ -56,6 +56,25 @@ subroutine mpp_init( flags,localcomm )
   tick_rate = 1./ticks_per_sec
   clock0 = mpp_clock_id( 'Total runtime', flags=MPP_CLOCK_SYNC )
 
+  ! Initialize mpp_datatypes
+  ! NOTE: mpp_datatypes is unused in serial mode; this is an empty list
+  datatypes%head => null()
+  datatypes%tail => null()
+  datatypes%length = 0
+
+  ! Create the bytestream (default) mpp_datatype
+  ! NOTE: mpp_byte is unused in serial mode
+  mpp_byte%counter = -1
+  mpp_byte%ndims = -1
+  allocate(mpp_byte%sizes(0))
+  allocate(mpp_byte%subsizes(0))
+  allocate(mpp_byte%starts(0))
+  mpp_byte%etype = -1
+  mpp_byte%id = -1
+
+  mpp_byte%prev => null()
+  mpp_byte%next => null()
+
   if( PRESENT(flags) )then
      debug   = flags.EQ.MPP_DEBUG
      verbose = flags.EQ.MPP_VERBOSE .OR. debug
@@ -1046,3 +1065,55 @@ end subroutine mpp_exit
 #define MPP_TYPE_BYTELEN_ 8
 #define MPI_TYPE_ MPI_REAL8
 #include <mpp_alltoall_nocomm.h>
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!                                                                             !
+!            DATA TRANSFER TYPES: mpp_type_create, mpp_type_free              !
+!                                                                             !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+#define MPP_TYPE_CREATE_ mpp_type_create_int4
+#define MPP_TYPE_ integer(INT_KIND)
+#define MPI_TYPE_ MPI_INTEGER4
+#include <mpp_type_nocomm.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_int8
+#define MPP_TYPE_ integer(LONG_KIND)
+#define MPI_TYPE_ MPI_INTEGER8
+#include <mpp_type_nocomm.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_real4
+#define MPP_TYPE_ real(FLOAT_KIND)
+#define MPI_TYPE_ MPI_REAL4
+#include <mpp_type_nocomm.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_real8
+#define MPP_TYPE_ real(DOUBLE_KIND)
+#define MPI_TYPE_ MPI_REAL8
+#include <mpp_type_nocomm.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_logical4
+#define MPP_TYPE_ logical(INT_KIND)
+#define MPI_TYPE_ MPI_INTEGER4
+#include <mpp_type_nocomm.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_logical8
+#define MPP_TYPE_ logical(LONG_KIND)
+#define MPI_TYPE_ MPI_INTEGER8
+#include <mpp_type_nocomm.h>
+
+! Clear preprocessor flags
+#undef MPI_TYPE_
+#undef MPP_TYPE_
+#undef MPP_TYPE_CREATE_
+
+subroutine mpp_type_free(dtype)
+    type(mpp_type), pointer, intent(inout) :: dtype
+
+    call mpp_error(NOTE, 'MPP_TYPE_FREE: ' &
+                         'This function should not be used in serial mode.')
+
+    ! For consistency with MPI, we deallocate the pointer
+    deallocate(dtype)
+
+end subroutine mpp_type_free

--- a/mpp/include/mpp_comm_sma.inc
+++ b/mpp/include/mpp_comm_sma.inc
@@ -68,6 +68,25 @@ subroutine mpp_init( flags,localcomm )
   tick_rate = 1./ticks_per_sec
   clock0 = mpp_clock_id( 'Total runtime', flags=MPP_CLOCK_SYNC )
 
+  ! Initialize mpp_datatypes
+  ! NOTE: mpp_datatypes are not implemented in SHMEM; this is an empty list
+  datatypes%head => null()
+  datatypes%tail => null()
+  datatypes%length = 0
+
+  ! Create the bytestream (default) mpp_datatype
+  ! NOTE: mpp_byte is unused in SHMEM
+  mpp_byte%counter = -1
+  mpp_byte%ndims = -1
+  allocate(mpp_byte%sizes(0))
+  allocate(mpp_byte%subsizes(0))
+  allocate(mpp_byte%starts(0))
+  mpp_byte%etype = -1
+  mpp_byte%id = -1
+
+  mpp_byte%prev => null()
+  mpp_byte%next => null()
+
   if( PRESENT(flags) )then
      debug   = flags.EQ.MPP_DEBUG
      verbose = flags.EQ.MPP_VERBOSE .OR. debug
@@ -1154,6 +1173,53 @@ end subroutine mpp_malloc
 #define MPP_TYPE_BYTELEN_ 8
 #define MPI_TYPE_ MPI_REAL8
 #include <mpp_alltoall_sma.h>
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!                                                                             !
+!            DATA TRANSFER TYPES: mpp_type_create, mpp_type_free              !
+!                                                                             !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+#define MPP_TYPE_CREATE_ mpp_type_create_int4
+#define MPP_TYPE_ integer(INT_KIND)
+#define MPI_TYPE_ MPI_INTEGER4
+#include <mpp_type_sma.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_int8
+#define MPP_TYPE_ integer(LONG_KIND)
+#define MPI_TYPE_ MPI_INTEGER8
+#include <mpp_type_sma.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_real4
+#define MPP_TYPE_ real(FLOAT_KIND)
+#define MPI_TYPE_ MPI_REAL4
+#include <mpp_type_sma.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_real8
+#define MPP_TYPE_ real(DOUBLE_KIND)
+#define MPI_TYPE_ MPI_REAL8
+#include <mpp_type_sma.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_logical4
+#define MPP_TYPE_ logical(INT_KIND)
+#define MPI_TYPE_ MPI_INTEGER4
+#include <mpp_type_sma.h>
+
+#define MPP_TYPE_CREATE_ mpp_type_create_logical8
+#define MPP_TYPE_ logical(LONG_KIND)
+#define MPI_TYPE_ MPI_INTEGER8
+#include <mpp_type_sma.h>
+
+! Clear preprocessor flags
+#undef MPI_TYPE_
+#undef MPP_TYPE_
+#undef MPP_TYPE_CREATE_
+
+subroutine mpp_type_free(dtype)
+    type(mpp_type), pointer, intent(inout) :: dtype
+
+    call mpp_error(FATAL, 'MPP_TYPE_FREE: Unsupported for SHMEM.')
+end subroutine mpp_type_free
 
 !#######################################################################
 !these local versions are written for grouping into shmem_integer_wait

--- a/mpp/include/mpp_do_global_field.h
+++ b/mpp/include/mpp_do_global_field.h
@@ -1,21 +1,3 @@
-!***********************************************************************
-!*                   GNU Lesser General Public License
-!*
-!* This file is part of the GFDL Flexible Modeling System (FMS).
-!*
-!* FMS is free software: you can redistribute it and/or modify it under
-!* the terms of the GNU Lesser General Public License as published by
-!* the Free Software Foundation, either version 3 of the License, or (at
-!* your option) any later version.
-!*
-!* FMS is distributed in the hope that it will be useful, but WITHOUT
-!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
-!* for more details.
-!*
-!* You should have received a copy of the GNU Lesser General Public
-!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
-!***********************************************************************
     subroutine MPP_DO_GLOBAL_FIELD_3D_( domain, local, global, tile, ishift, jshift, flags, default_data)
 !get a global field from a local field
 !local field may be on compute OR data domain
@@ -271,3 +253,237 @@
           
       return
     end subroutine MPP_DO_GLOBAL_FIELD_3D_
+
+
+    subroutine MPP_DO_GLOBAL_FIELD_A2A_3D_( domain, local, global, tile, ishift, jshift, flags, default_data)
+!get a global field from a local field
+!local field may be on compute OR data domain
+      type(domain2D), intent(in)    :: domain
+      integer, intent(in)           :: tile, ishift, jshift
+      MPP_TYPE_, intent(in), contiguous, target :: local(:,:,:)
+      MPP_TYPE_, intent(out), contiguous, target :: global(domain%x(tile)%global%begin:,domain%y(tile)%global%begin:,:)
+      integer, intent(in), optional :: flags
+      MPP_TYPE_, intent(in), optional :: default_data
+
+      integer :: i, j, k, m, n, nd, nwords, lpos, rpos, ioff, joff, from_pe, root_pe, tile_id
+      integer :: ke, isc, iec, jsc, jec, is, ie, js, je
+      integer :: ipos, jpos
+      logical :: xonly, yonly, root_only, global_on_this_pe
+
+      ! Alltoallw vectors
+      MPP_TYPE_, dimension(:), pointer :: plocal, pglobal
+
+      integer, dimension(:), allocatable :: sendcounts(:), recvcounts(:)
+      integer, dimension(:), allocatable :: sdispls(:), rdispls(:)
+      type(mpp_type), allocatable :: sendtypes(:), recvtypes(:)
+      integer, dimension(3) :: array_of_subsizes, array_of_starts
+      integer :: n_sends, n_ax, pe
+      integer :: isg, jsg
+      integer, allocatable :: pelist(:), axis_pelist(:), pelist_idx(:)
+
+      if (.NOT.module_is_initialized) &
+          call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: must first call mpp_domains_init.' )
+
+      ! Validate flag consistency and configure the function
+      xonly = .FALSE.
+      yonly = .FALSE.
+      root_only = .FALSE.
+      if( PRESENT(flags) ) then
+         xonly = BTEST(flags,EAST)
+         yonly = BTEST(flags,SOUTH)
+         if( .NOT.xonly .AND. .NOT.yonly )call mpp_error( WARNING,  &
+                   'MPP_GLOBAL_FIELD: you must have flags=XUPDATE, YUPDATE or XUPDATE+YUPDATE' )
+         if(xonly .AND. yonly) then
+            xonly = .false.; yonly = .false.
+         endif
+         root_only = BTEST(flags, ROOT_GLOBAL)
+         if( (xonly .or. yonly) .AND. root_only ) then
+            call mpp_error( WARNING, 'MPP_GLOBAL_FIELD: flags = XUPDATE+GLOBAL_ROOT_ONLY or ' // &
+                 'flags = YUPDATE+GLOBAL_ROOT_ONLY is not supported, will ignore GLOBAL_ROOT_ONLY' )
+            root_only = .FALSE.
+         endif
+      endif
+
+      global_on_this_pe =  .NOT. root_only .OR. domain%pe == domain%tile_root_pe
+
+      ! Calculate offset for truncated global fields
+      ! NOTE: We do not check contiguity of global subarrays, and assume that
+      !       they have been copied to a contigous array.
+      ipos = 0; jpos = 0
+      if(global_on_this_pe ) then
+         if(size(local,3).NE.size(global,3) ) call mpp_error( FATAL, &
+              'MPP_GLOBAL_FIELD: mismatch of third dimension size of global and local')
+         if( size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. size(global,2).NE.(domain%y(tile)%global%size+jshift))then
+            if(xonly) then
+               if(size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. &
+                   size(global,2).NE.(domain%y(tile)%compute%size+jshift)) &
+                  call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain for xonly global field.' )
+               jpos = -domain%y(tile)%compute%begin + 1
+            else if(yonly) then
+               if(size(global,1).NE.(domain%x(tile)%compute%size+ishift) .OR. &
+                   size(global,2).NE.(domain%y(tile)%global%size+jshift)) &
+                  call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain for yonly global field.' )
+               ipos = -domain%x(tile)%compute%begin + 1
+            else
+               call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain.' )
+            endif
+         endif
+      endif
+
+      ! TODO: Remove the +1/-1 correction
+      ! NOTE: Since local is assumed to contiguously match the data domain, this
+      !       is not a useful check.  But maybe someday we can support compute
+      !       domains.
+      if( size(local,1).EQ.(domain%x(tile)%compute%size+ishift) .AND. size(local,2).EQ.(domain%y(tile)%compute%size+jshift) )then
+         !local is on compute domain
+         ioff = -domain%x(tile)%compute%begin
+         joff = -domain%y(tile)%compute%begin
+      else if( size(local,1).EQ.(domain%x(tile)%memory%size+ishift) .AND. size(local,2).EQ.(domain%y(tile)%memory%size+jshift) )then
+         !local is on data domain
+         ioff = -domain%x(tile)%data%begin
+         joff = -domain%y(tile)%data%begin
+      else
+         call mpp_error( FATAL, 'MPP_GLOBAL_FIELD_: incoming field array must match either compute domain or memory domain.' )
+      end if
+
+      ke  = size(local,3)
+      isc = domain%x(tile)%compute%begin; iec = domain%x(tile)%compute%end+ishift
+      jsc = domain%y(tile)%compute%begin; jec = domain%y(tile)%compute%end+jshift
+      isg = domain%x(1)%global%begin; jsg = domain%y(1)%global%begin
+
+      if(global_on_this_pe) then
+         !z1l: initialize global = 0 to support mask domain
+         if(PRESENT(default_data)) then
+            global = default_data
+         else
+#ifdef LOGICAL_VARIABLE
+            global = .false.
+#else
+            global = 0
+#endif
+         endif
+      endif
+
+      ! if there is more than one tile on this pe, then no decomposition for
+      ! all tiles on this pe, so we can just return
+      if(size(domain%x(:))>1) then
+         !--- the following is needed to avoid deadlock.
+         if( tile == size(domain%x(:)) ) call mpp_sync_self( )
+         return
+      end if
+
+      root_pe = mpp_root_pe()
+
+      ! Generate the pelist
+      ! TODO: Add these to the domain API
+      ! TODO: Clean this shit up
+      if (xonly) then
+          n_ax = size(domain%x(1)%list(:))
+          allocate(axis_pelist(n_ax))
+          axis_pelist = [ (domain%x(1)%list(i)%pe, i = 0, n_ax-1) ]
+
+          nd = count(axis_pelist >= 0)
+          allocate(pelist(nd), pelist_idx(0:nd-1))
+          pelist = pack(axis_pelist, mask=(axis_pelist >= 0))
+          pelist_idx = pack([(i, i=0, n_ax-1)], mask=(axis_pelist >= 0))
+
+          deallocate(axis_pelist)
+      else if (yonly) then
+          n_ax = size(domain%y(1)%list(:))
+          allocate(axis_pelist(n_ax))
+          axis_pelist = [ (domain%y(1)%list(i)%pe, i = 0, n_ax-1) ]
+
+          nd = count(axis_pelist >= 0)
+          allocate(pelist(nd), pelist_idx(0:nd-1))
+          pelist = pack(axis_pelist, mask=(axis_pelist >= 0))
+          pelist_idx = pack([(i, i=0, n_ax-1)], mask=(axis_pelist >= 0))
+
+          deallocate(axis_pelist)
+      else
+          nd = size(domain%list(:))
+          allocate(pelist(nd), pelist_idx(0:nd-1))
+          call mpp_get_pelist(domain, pelist)
+          pelist_idx = [ (i, i=0, nd-1) ]
+      end if
+
+      ! Allocate message data buffers
+      allocate(sendcounts(0:nd-1))
+      allocate(sdispls(0:nd-1))
+      allocate(sendtypes(0:nd-1))
+      sendcounts(:) = 0
+      sdispls(:) = 0
+      sendtypes(:) = mpp_byte
+
+      allocate(recvcounts(0:nd-1))
+      allocate(rdispls(0:nd-1))
+      allocate(recvtypes(0:nd-1))
+      recvcounts(:) = 0
+      rdispls(:) = 0
+      recvtypes(:) = mpp_byte
+
+      array_of_subsizes = [iec - isc + 1, jec - jsc + 1, size(local, 3)]
+      array_of_starts = [isc + ioff, jsc + joff, 0]
+
+      n_sends = merge(1, nd, root_only) ! 1 if root_only else nd
+      do n = 0, n_sends - 1
+          sendcounts(n) = 1
+
+          call mpp_type_create( &
+              local, &
+              array_of_subsizes, &
+              array_of_starts, &
+              sendtypes(n) &
+          )
+      end do
+
+      ! Receive configuration
+      if (global_on_this_pe) then
+          do n = 0, nd - 1
+              recvcounts(n) = 1
+              pe = pelist_idx(n)
+
+              if (xonly) then
+                  is = domain%x(1)%list(pe)%compute%begin
+                  ie = domain%x(1)%list(pe)%compute%end + ishift
+                  js = jsc; je = jec
+              else if (yonly) then
+                  is = isc; ie = iec
+                  js = domain%y(1)%list(pe)%compute%begin
+                  je = domain%y(1)%list(pe)%compute%end + jshift
+              else
+                  is = domain%list(pe)%x(1)%compute%begin
+                  ie = domain%list(pe)%x(1)%compute%end + ishift
+                  js = domain%list(pe)%y(1)%compute%begin
+                  je = domain%list(pe)%y(1)%compute%end + jshift
+              end if
+
+              array_of_subsizes = [ie - is + 1, je - js + 1, ke]
+              array_of_starts = [is - isg + ipos, js - jsg + jpos, 0]
+
+              call mpp_type_create( &
+                  global, &
+                  array_of_subsizes, &
+                  array_of_starts, &
+                  recvtypes(n) &
+              )
+          end do
+      end if
+
+      plocal(1:size(local)) => local
+      pglobal(1:size(global)) => global
+
+      call mpp_alltoall(plocal, sendcounts, sdispls, sendtypes, &
+                        pglobal, recvcounts, rdispls, recvtypes, &
+                        pelist)
+
+      plocal => null()
+      pglobal => null()
+
+      ! Cleanup
+      deallocate(pelist)
+      deallocate(sendcounts, sdispls, sendtypes)
+      deallocate(recvcounts, rdispls, recvtypes)
+
+      call mpp_sync_self()
+
+    end subroutine MPP_DO_GLOBAL_FIELD_A2A_3D_

--- a/mpp/include/mpp_domains_reduce.inc
+++ b/mpp/include/mpp_domains_reduce.inc
@@ -499,6 +499,7 @@
 !****************************************************
 #undef MPP_DO_GLOBAL_FIELD_3D_
 #define MPP_DO_GLOBAL_FIELD_3D_ mpp_do_global_field2D_r8_3d
+#define MPP_DO_GLOBAL_FIELD_A2A_3D_ mpp_do_global_field2D_a2a_r8_3d
 #undef MPP_TYPE_
 #define MPP_TYPE_ real(DOUBLE_KIND)
 #include <mpp_do_global_field.h>                                    
@@ -506,6 +507,7 @@
 #ifdef OVERLOAD_C8
 #undef MPP_DO_GLOBAL_FIELD_3D_
 #define MPP_DO_GLOBAL_FIELD_3D_ mpp_do_global_field2D_c8_3d
+#define MPP_DO_GLOBAL_FIELD_A2A_3D_ mpp_do_global_field2D_a2a_c8_3d
 #undef MPP_TYPE_
 #define MPP_TYPE_ complex(DOUBLE_KIND)
 #include <mpp_do_global_field.h>                                    
@@ -514,12 +516,14 @@
 #ifndef no_8byte_integers
 #undef MPP_DO_GLOBAL_FIELD_3D_
 #define MPP_DO_GLOBAL_FIELD_3D_ mpp_do_global_field2D_i8_3d
+#define MPP_DO_GLOBAL_FIELD_A2A_3D_ mpp_do_global_field2D_a2a_i8_3d
 #undef MPP_TYPE_
 #define MPP_TYPE_ integer(LONG_KIND)
 #include <mpp_do_global_field.h>                                    
 
 #undef MPP_DO_GLOBAL_FIELD_3D_
 #define MPP_DO_GLOBAL_FIELD_3D_ mpp_do_global_field2D_l8_3d
+#define MPP_DO_GLOBAL_FIELD_A2A_3D_ mpp_do_global_field2D_a2a_l8_3d
 #define LOGICAL_VARIABLE
 #undef MPP_TYPE_
 #define MPP_TYPE_ logical(LONG_KIND)
@@ -530,6 +534,7 @@
 #ifdef OVERLOAD_R4
 #undef MPP_DO_GLOBAL_FIELD_3D_
 #define MPP_DO_GLOBAL_FIELD_3D_ mpp_do_global_field2D_r4_3d
+#define MPP_DO_GLOBAL_FIELD_A2A_3D_ mpp_do_global_field2D_a2a_r4_3d
 #undef MPP_TYPE_
 #define MPP_TYPE_ real(FLOAT_KIND)
 #include <mpp_do_global_field.h>                                    
@@ -538,6 +543,7 @@
 #ifdef OVERLOAD_C4
 #undef MPP_DO_GLOBAL_FIELD_3D_
 #define MPP_DO_GLOBAL_FIELD_3D_ mpp_do_global_field2D_c4_3d
+#define MPP_DO_GLOBAL_FIELD_A2A_3D_ mpp_do_global_field2D_a2a_c4_3d
 #undef MPP_TYPE_
 #define MPP_TYPE_ complex(FLOAT_KIND)
 #include <mpp_do_global_field.h>                                    
@@ -545,15 +551,16 @@
 
 #undef MPP_DO_GLOBAL_FIELD_3D_
 #define MPP_DO_GLOBAL_FIELD_3D_ mpp_do_global_field2D_i4_3d
+#define MPP_DO_GLOBAL_FIELD_A2A_3D_ mpp_do_global_field2D_a2a_i4_3d
 #undef MPP_TYPE_
 #define MPP_TYPE_ integer(INT_KIND)
 #include <mpp_do_global_field.h>                                    
 
 #undef MPP_DO_GLOBAL_FIELD_3D_
 #define MPP_DO_GLOBAL_FIELD_3D_ mpp_do_global_field2D_l4_3d
+#define MPP_DO_GLOBAL_FIELD_A2A_3D_ mpp_do_global_field2D_a2a_l4_3d
 #define LOGICAL_VARIABLE
 #undef MPP_TYPE_
 #define MPP_TYPE_ logical(INT_KIND)
 #include <mpp_do_global_field.h>
 #undef LOGICAL_VARIABLE
-

--- a/mpp/include/mpp_type_mpi.h
+++ b/mpp/include/mpp_type_mpi.h
@@ -1,0 +1,82 @@
+subroutine MPP_TYPE_CREATE_(field, array_of_subsizes, array_of_starts, &
+                            dtype_out)
+    MPP_TYPE_, intent(in) :: field(:,:,:)
+    integer, intent(in) :: array_of_subsizes(:)
+    integer, intent(in) :: array_of_starts(:)
+    type(mpp_type), target, intent(out) :: dtype_out
+
+    type(mpp_type), pointer :: dtype
+    integer :: newtype      ! MPI datatype ID
+
+    if (.NOT. module_is_initialized) &
+        call mpp_error(FATAL, 'MPP_TYPE_CREATE_: You must first call mpp_init.')
+
+    if (current_clock .NE. 0) &
+        call SYSTEM_CLOCK(start_tick)
+
+    if (verbose) &
+        call mpp_error(NOTE, 'MPP_TYPE_CREATE_: &
+                             &using MPI_Type_create_subarray...')
+
+    dtype => datatypes%head
+    ! TODO: Check mpp_byte
+
+    ! Check if mpp_type already exists
+    do while (.not. associated(dtype))
+        dtype => dtype%next
+
+        if (dtype%ndims /= rank(field)) cycle
+        if (any(dtype%sizes /= shape(field))) cycle
+        if (any(dtype%subsizes /= array_of_subsizes)) cycle
+        if (any(dtype%starts /= array_of_starts)) cycle
+        if (dtype%etype /= MPI_TYPE_) cycle
+
+        ! If all parameters match, then the datatype exists and return dtype
+        dtype%counter = dtype%counter + 1
+        dtype_out = dtype
+        return
+    end do
+
+    ! The type does not exist; create a new internal type
+    call MPI_Type_create_subarray( &
+        rank(field), &
+        shape(field), &
+        array_of_subsizes, &
+        array_of_starts, &
+        MPI_ORDER_FORTRAN, &
+        MPI_TYPE_, &
+        newtype, &
+        error &
+    )
+
+    ! Register on the MPI runtime
+    call MPI_Type_commit(newtype, error)
+
+    ! Create new entry
+    allocate(dtype)
+    allocate(dtype%sizes(rank(field)))
+    allocate(dtype%subsizes(rank(field)))
+    allocate(dtype%starts(rank(field)))
+
+    ! Populate values
+    dtype%counter = 1
+    dtype%ndims = rank(field)
+    dtype%sizes = shape(field)
+    dtype%subsizes = array_of_subsizes
+    dtype%starts = array_of_starts
+    dtype%etype = MPI_TYPE_
+    dtype%id = newtype
+
+    ! Add dtype to the list
+    dtype%prev => datatypes%tail
+    dtype%prev%next => dtype
+    datatypes%tail => dtype
+    datatypes%length = datatypes%length + 1
+
+    ! Copy dtype to output
+    dtype_out = dtype
+
+    if (current_clock .NE. 0) &
+        call increment_current_clock(EVENT_TYPE_CREATE, MPP_TYPE_BYTELEN_)
+
+end subroutine MPP_TYPE_CREATE_

--- a/mpp/include/mpp_type_nocomm.h
+++ b/mpp/include/mpp_type_nocomm.h
@@ -1,0 +1,22 @@
+subroutine MPP_TYPE_CREATE_(field, array_of_subsizes, array_of_starts, dtype)
+    MPP_TYPE_, intent(in) :: field(:,:,:)
+    integer, intent(in) :: array_of_subsizes(:)
+    integer, intent(in) :: array_of_starts(:)
+    type(mpp_type), target, intent(out) :: dtype
+
+    if (.NOT. module_is_initialized) &
+        call mpp_error(FATAL, 'MPP_TYPE_CREATE: You must first call mpp_init.')
+
+    if (current_clock .NE. 0) &
+        call SYSTEM_CLOCK(start_tick)
+
+    call mpp_error(NOTE, 'MPP_TYPE_CREATE: &
+                         &This function is not used in serial mode.')
+
+    ! For consistency with the MPI version, we return a valid mpp_type
+    dtype = mpp_byte
+
+    if (current_clock .NE. 0) &
+        call increment_current_clock(EVENT_TYPE_CREATE, MPP_TYPE_BYTELEN_)
+
+end subroutine MPP_TYPE_CREATE_

--- a/mpp/include/mpp_type_sma.h
+++ b/mpp/include/mpp_type_sma.h
@@ -1,0 +1,8 @@
+subroutine MPP_TYPE_CREATE_(field, array_of_subsizes, array_of_starts, dtype)
+    MPP_TYPE_, intent(in) :: field(:,:,:)
+    integer, intent(in) :: array_of_subsizes(:)
+    integer, intent(in) :: array_of_starts(:)
+    type(mpp_type), target, intent(out) :: dtype
+
+    call mpp_error(FATAL, 'MPP_TYPE_CREATE_: Unsupported in SHMEM.')
+end subroutine MPP_TYPE_CREATE_

--- a/mpp/include/mpp_util_mpi.inc
+++ b/mpp/include/mpp_util_mpi.inc
@@ -133,7 +133,8 @@ function get_peset(pelist)
   peset(i)%count = size(sorted(:))
 
   call MPI_GROUP_INCL( peset(current_peset_num)%group, size(sorted(:)), sorted-mpp_root_pe(), peset(i)%group, error )
-  call MPI_COMM_CREATE( peset(current_peset_num)%id, peset(i)%group, peset(i)%id, error )
+  call MPI_COMM_CREATE_GROUP(peset(current_peset_num)%id, peset(i)%group, &
+                             DEFAULT_TAG, peset(i)%id, error )
 #ifdef use_MPI_SMA
   n = size(sorted(:))
   write( text, '(20i6)' )( sorted(l), l=1,min(n,20) )
@@ -259,4 +260,3 @@ subroutine mpp_sync_self( pelist, check, request, msg_size, msg_type)
   if( debug .and. (current_clock.NE.0) )call increment_current_clock(EVENT_WAIT)
   return
 end subroutine mpp_sync_self
-

--- a/mpp/mpp_domains.F90
+++ b/mpp/mpp_domains.F90
@@ -156,6 +156,8 @@ module mpp_domains_mod
   use mpp_mod,                only : mpp_max, mpp_min, mpp_sum, mpp_get_current_pelist, mpp_broadcast
   use mpp_mod,                only : mpp_sync, mpp_init, mpp_malloc, lowercase
   use mpp_mod,                only : input_nml_file, mpp_alltoall
+  use mpp_mod,                only : mpp_type, mpp_byte
+  use mpp_mod,                only : mpp_type_create, mpp_type_free
   use mpp_mod,                only : COMM_TAG_1, COMM_TAG_2, COMM_TAG_3, COMM_TAG_4
   use mpp_memutils_mod,       only : mpp_memuse_begin, mpp_memuse_end
   use mpp_pset_mod,           only : mpp_pset_init
@@ -697,8 +699,9 @@ module mpp_domains_mod
   logical           :: debug_message_passing = .false.
   integer           :: nthread_control_loop = 8
   logical           :: efp_sum_overflow_check = .false.
+  logical           :: use_alltoallw = .false.
   namelist /mpp_domains_nml/ debug_update_domain, domain_clocks_on, debug_message_passing, nthread_control_loop, &
-                             efp_sum_overflow_check
+                             efp_sum_overflow_check, use_alltoallw
 
   !***********************************************************************
 
@@ -2107,6 +2110,25 @@ end interface
 #endif
      module procedure mpp_do_global_field2D_i4_3d
      module procedure mpp_do_global_field2D_l4_3d
+  end interface
+
+  interface mpp_do_global_field_a2a
+     module procedure mpp_do_global_field2D_a2a_r8_3d
+#ifdef OVERLOAD_C8
+     module procedure mpp_do_global_field2D_a2a_c8_3d
+#endif
+#ifndef no_8byte_integers
+     module procedure mpp_do_global_field2D_a2a_i8_3d
+     module procedure mpp_do_global_field2D_a2a_l8_3d
+#endif
+#ifdef OVERLOAD_R4
+     module procedure mpp_do_global_field2D_a2a_r4_3d
+#endif
+#ifdef OVERLOAD_C4
+     module procedure mpp_do_global_field2D_a2a_c4_3d
+#endif
+     module procedure mpp_do_global_field2D_a2a_i4_3d
+     module procedure mpp_do_global_field2D_a2a_l4_3d
   end interface
 
   interface mpp_global_field_ug

--- a/mpp/mpp_parameter.F90
+++ b/mpp/mpp_parameter.F90
@@ -33,7 +33,7 @@ module mpp_parameter_mod
   public :: MPP_CLOCK_DETAILED, CLOCK_COMPONENT, CLOCK_SUBCOMPONENT, CLOCK_MODULE_DRIVER
   public :: CLOCK_MODULE, CLOCK_ROUTINE, CLOCK_LOOP, CLOCK_INFRA, MAX_BINS
   public :: EVENT_ALLREDUCE, EVENT_BROADCAST, EVENT_RECV, EVENT_SEND, EVENT_WAIT
-  public :: EVENT_ALLTOALL
+  public :: EVENT_ALLTOALL, EVENT_TYPE_CREATE, EVENT_TYPE_FREE
   public :: DEFAULT_TAG
   public :: COMM_TAG_1,  COMM_TAG_2,  COMM_TAG_3,  COMM_TAG_4
   public :: COMM_TAG_5,  COMM_TAG_6,  COMM_TAG_7,  COMM_TAG_8
@@ -69,6 +69,7 @@ module mpp_parameter_mod
   integer, parameter :: MAX_CLOCKS=400, MAX_EVENT_TYPES=5, MAX_EVENTS=40000
   integer, parameter :: EVENT_ALLREDUCE=1, EVENT_BROADCAST=2, EVENT_RECV=3, EVENT_SEND=4, EVENT_WAIT=5
   integer, parameter :: EVENT_ALLTOALL=6
+  integer, parameter :: EVENT_TYPE_CREATE=7, EVENT_TYPE_FREE=8
   integer, parameter :: MPP_CLOCK_SYNC=1, MPP_CLOCK_DETAILED=2
   integer            :: DEFAULT_TAG = 1
   !--- implimented to centralize _FILL_ values for land_model.F90 into mpp_mod


### PR DESCRIPTION
This is the work of @marshallward
```
git cherry-pick d216cfd4506be1f369c8a265cb40e9f9b34321c2
```

This patch contains three new features for FMS: Support for MPI datatypes, an
MPI_Alltoallw interface, and modifications to mpp_global_field to use these
changes for select operations.

These changes were primarily made to improve stability of large (>4000
rank) MPI jobs under OpenMPI at NCI.

There are differences in the performance of mpp_global_field,
occasionally even very large differences, but there is no consistency
across various MPI libraries.  One method will be faster in one library,
and slower in another, even across MPI versions.  Generally, the
MPI_Alltoallw method showed improved performance on our system, but this
is not a universal result.  We therefore introduce a flag to control
this feature.

The inclusion of MPI_Type support may also be seen as an opportunity to
introduce other new MPI features for other operations, e.g. halo
exchange.

Detailed changes are summarised below.

- MPI data transfer type ("MPI_Type") support has been added to FMS.  This is
  done with the following features:

  -  A `mpp_type` derived type has been added, which manages the type details
    and hides the MPI internals from the model developer.  Types are managed
    inside of an internal linked list, `datatypes`.

    Note: The name `mpp_type` is very similar to the preprocessor variable
    `MPP_TYPE_` and should possibly be renamed to something else, e.g.
    `mpp_datatype`.*

  - `mpp_type_create` and `mpp_type_free` are used to create and release these
    types within the MPI library.  These append and remove mpp_types from the
    internal linked list, and include reference counters to manage duplicates.

  - A `mpp_byte` type is created as a module-level variable for default
    operations.

    NOTE: As the first element of the list, it also inadvertently provides
    access to the rest of `datatypes`, which is private, but there is probably
    some ways to address this.*

- A MPI_Alltoallw wrapper, using MPI_Types, has been added to the mpp_alltoall
  interface.

- An implementation of mpp_global_field using MPI_Alltoallw and mpp_types has
  been added.  In addition to replacing the point-to-point operations with a
  collective, it also eliminates the need to use the internal MPP stack.

  Since MPI_Alltoallw requires that the input field by contiguous, it is only
  enabled for data domains (i.e. compute + halo).  This limitation can be
  overcome, either by copying or more careful attention to layout, but it can
  be addressed in a future patch.

  This method is enabled in the `mpp_domains_nml` namelist group, by setting
  the `use_alltoallw` flag to True.

Provisional interfaces to SHMEM and serial ("nocomm") builds have been added,
although they are as yet untested and primarily meant as placeholders for now.

This patch also includes the following changes to support this work.

- In `get_peset`, the method used to generate MPI subcommunicators has been
  changed; specifically `MPI_Comm_create` has been replaced with
  `MPI_Comm_create_group`.  The former is blocking over all ranks, while the
  latter is only blocking over ranks in the subgroup.

  This was done to accommodate IO domains of a single rank, usually due to
  masking, which would result in no communication and cause a model hang.

  It seems that more recent changes in FMS related to handling single-rank
  communicators were made to avoid this particular scenario from happening, but
  I still think that it's more correct to use `MPI_Comm_create_group` and have
  left the change.

  This is an MPI 3.0 feature, so this might be an issue for older MPI
  libraries.

- Logical interfaces added to mpp_alltoall and mpp_alltoallv

- Single-rank PE checks in mpp_alltoall were removed to prevent model hangs
  with the subcommunicators.

- NULL_PE checks have been added to the original point-to-point implementation
  of mpp_global_field, although these may not be required anymore due to
  changes in the subcommunicator implementation.

  This work was by Nic Hannah, and may actually be part of an existing pull
  request.  (TODO: Check this!)

- Timer events have been added to mpp_type_create and mpp_type_free, although
  they are not yet initialized anywhere.

- The diagnostic field count was increased from 150 to 250, to support the
  current needs of researchers.