### PR TITLE
Add missing commits from MOM5 repo

### DIFF
--- a/axis_utils/axis_utils.F90
+++ b/axis_utils/axis_utils.F90
@@ -876,7 +876,7 @@ integer           :: unit, ierr, io
 end program test
 
 
-#endif /* test_axis_utils */
+#endif
 
 
 

--- a/exchange/test_xgrid.F90
+++ b/exchange/test_xgrid.F90
@@ -980,4 +980,4 @@ end program xgrid_test
 module null_test_xgrid
 end module  
 
-#endif /* test_mpp */
+#endif

--- a/memutils/memutils.F90
+++ b/memutils/memutils.F90
@@ -241,7 +241,7 @@ module memutils_mod
     if( present(hplast   ) )hplast    = IHPSTAT(14) !Last word address
     return
   end function hplen
-#endif /* _CRAY */
+#endif
 
 #ifdef _CRAYT90
   integer function stklen(            stkhiwm, stknumber, stktotal, stkmost, stkgrew, stkgtimes )
@@ -259,7 +259,7 @@ module memutils_mod
     if( present(stkgtimes) )stkgtimes = istat(7) !#times stack grew
     return
   end function stklen
-#endif /* _CRAYT90 */
+#endif
 
 !cache utilities: need to write version for other argument types
   function get_l1_cache_line(a)

--- a/mpp/include/mpp_io_write.inc
+++ b/mpp/include/mpp_io_write.inc
@@ -1032,7 +1032,7 @@
       else
           call mpp_error( FATAL, 'WRITE_ATTRIBUTE_NETCDF: one of rval, ival, cval must be present.' )
       end if
-#endif /* use_netCDF */
+#endif
       return
     end subroutine write_attribute_netcdf
 

--- a/mpp/include/mpp_update_domains2D.h
+++ b/mpp/include/mpp_update_domains2D.h
@@ -620,4 +620,4 @@
 
       return
     end subroutine MPP_UPDATE_DOMAINS_5D_V_
-#endif /* VECTOR_FIELD_ */
+#endif

--- a/mpp/include/mpp_update_domains2D_ad.h
+++ b/mpp/include/mpp_update_domains2D_ad.h
@@ -417,4 +417,4 @@
                                   whalo, ehalo, shalo, nhalo, name, tile_count )
       return
     end subroutine MPP_UPDATE_DOMAINS_AD_5D_V_
-#endif /* VECTOR_FIELD_ */
+#endif

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -1297,7 +1297,7 @@ private
   !(t3e: fixed on 3.3 I believe)
   integer, parameter :: MPI_INTEGER8=MPI_INTEGER
 #endif
-#endif /* use_libMPI */
+#endif
 #ifdef use_MPI_SMA
 #include <mpp/shmem.fh>
   integer :: pSync(SHMEM_BARRIER_SYNC_SIZE)

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -173,8 +173,9 @@ module mpp_mod
   use shmem_interface
 #endif
 
-#if defined(use_libMPI) && defined(sgi_mipspro)
+#if defined(use_libMPI) && (defined(sgi_mipspro) || (__GNUC__ >= 11))
   use mpi
+#define MPI_IMPORTED 1
 #endif
 
   use mpp_parameter_mod, only : MPP_VERBOSE, MPP_DEBUG, ALL_PES, ANY_PE, NULL_PE
@@ -205,9 +206,9 @@ private
 #include <mpp/shmem.fh>
 #endif
 
-#if defined(use_libMPI) && !defined(sgi_mipspro)
+#if defined(use_libMPI) && !defined(MPI_IMPORTED)
 #include <mpif.h>   
-!sgi_mipspro gets this from 'use mpi'
+! !sgi_mipspro gets this from 'use mpi'
 #endif
 
   !--- public paramters  -----------------------------------------------

--- a/mpp/mpp_parameter.F90
+++ b/mpp/mpp_parameter.F90
@@ -117,7 +117,7 @@ module mpp_parameter_mod
 ! combination with the flag parameter defined above to create a unique identifier for
 ! each Domain+flags combination. Therefore, the value of any flag must not exceed DOMAIN_ID_BASE.
 ! integer(LONG_KIND), parameter :: DOMAIN_ID_BASE=INT( 2**(4*LONG_KIND),KIND=LONG_KIND )
-  integer(LONG_KIND), parameter :: DOMAIN_ID_BASE=Z'0000000100000000' ! Workaround for 64bit init problem
+  integer(LONG_KIND), parameter :: DOMAIN_ID_BASE=INT(Z'0000000100000000', kind=LONG_KIND) ! Workaround for 64bit init problem
   integer, parameter :: NON_BITWISE_EXACT_SUM=0
   integer, parameter :: BITWISE_EXACT_SUM=1
   integer, parameter :: BITWISE_EFP_SUM=2

--- a/mpp/test_mpp.F90
+++ b/mpp/test_mpp.F90
@@ -543,4 +543,4 @@ end program test
 module null_mpp_test
 end module  
 
-#endif /* test_mpp */
+#endif

--- a/mpp/threadloc.c
+++ b/mpp/threadloc.c
@@ -68,7 +68,7 @@ int find_nodenum(int mynodedev) {
 int mld_id_() { /* dummy routine for portability */
   return 0;
 }
-#endif /* sgi */
+#endif
 
 #ifdef test_threadloc
 void main(int argc, char **argv) {


### PR DESCRIPTION
There were some commits added directly to the MOM5 repo `src/shared` sub-directory as part of other PRs.

https://github.com/mom-ocean/MOM5/pull/351

https://github.com/mom-ocean/MOM5/pull/361

This was a mistake, and to fix it these commits will be added to this FMS fork and then incorporated back into the MOM5 repo with a proper subtree update.

The changes in this commit are fairly innocuous. For the most part they remove non-standard and superfluous pre-processor comments on `#endif` commands.

There are also a couple of changes to support FORTRAN90 `use mpi` syntax in later versions of GCC, and to allow the use of a [BOZ literal in a variable initialisation](https://gcc.gnu.org/onlinedocs/gcc-8.5.0/gfortran/BOZ-literal-constants.html).