### PR TITLE
Remove deprecated runner version for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ] 
+        os: [ ubuntu-20.04 ] 
         # gcc_v: [8, 9] # Version of GFortran we want to use.
         build: [ Release, Debug ]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Remove deprecated GitHub runner version from CI matrix

Fixes #10




